### PR TITLE
Cleanup test errors

### DIFF
--- a/source/modules/ModuleCache.lua
+++ b/source/modules/ModuleCache.lua
@@ -1,4 +1,5 @@
 local getEnv = require(script.Parent.getEnv)
+local generateScriptHeader = require(script.Parent.generateScriptHeader)
 
 local cache = {}
 
@@ -37,7 +38,7 @@ function ModuleCache.require(moduleScript)
         return accessModule(moduleScript)
     end
 
-    local moduleFn = loadstring(moduleScript.Source)
+    local moduleFn = loadstring(generateScriptHeader(moduleScript) .. moduleScript.Source)
     local env = getEnv(moduleScript)
     env.require = ModuleCache.require
 

--- a/source/modules/generateScriptHeader.lua
+++ b/source/modules/generateScriptHeader.lua
@@ -1,0 +1,15 @@
+local function generateScriptExtension(script)
+	if script:IsA("ModuleScript") then
+		return ".lua"
+	elseif script:IsA("LocalScript") then
+		return ".client.lua"
+	elseif script:IsA("Script") then
+		return ".server.lua"
+	end
+
+	return ""
+end
+
+return function(script)
+	return string.format("--[[%s%s]]\t", script.Name, generateScriptExtension(script))
+end

--- a/source/modules/runTests.lua
+++ b/source/modules/runTests.lua
@@ -2,6 +2,7 @@ local TestService = game:GetService("TestService")
 
 local getEnv = require(script.Parent.getEnv)
 local ModuleCache = require(script.Parent.ModuleCache)
+local generateScriptHeader = require(script.Parent.generateScriptHeader)
 
 return function()
     ModuleCache.clear()
@@ -9,7 +10,7 @@ return function()
     local scripts = TestService:GetChildren()
 
     for _, scriptObject in ipairs(scripts) do
-        local scriptFn = loadstring(scriptObject.Source)
+        local scriptFn = loadstring(generateScriptHeader(scriptObject) .. scriptObject.Source)
 
         local env = getEnv(scriptObject)
         env.require = ModuleCache.require
@@ -18,7 +19,11 @@ return function()
 
         local success, result = pcall(scriptFn)
         if not success then
-            error(string.format("Error running TestService Script %s: %s", scriptObject:GetFullName(), result))
+            local found = string.find(result, "%.%.%.\"]")
+            if found then
+                result = string.sub(result, found + 6)
+            end
+            TestService:Error(string.format("Error running: %s", result), scriptObject)
         end
     end
 end

--- a/source/modules/updateDirectories.lua
+++ b/source/modules/updateDirectories.lua
@@ -1,5 +1,4 @@
 local Watcher = require(script.Parent.Watcher)
-local runTests = require(script.Parent.runTests)
 
 local connection
 


### PR DESCRIPTION
Appends the file's name and extension to the top of the loadstring command so that when it throws, its easier to determine which file is having an issue.

The runTests error function has been swapped out in favor of TestService's Error function, which provides an argument for the source instance that is throwing by default. We also attempt to trim out the test runner's source using the `...]"` pattern.